### PR TITLE
Build os.environ loader

### DIFF
--- a/src/eggviron/environ_loader.py
+++ b/src/eggviron/environ_loader.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import logging
+import os
+
+
+class EnvironLoader:
+    """Load os.environ values"""
+
+    log = logging.getLogger(__name__)
+    name = "EnvironLoader"
+
+    def run(self) -> dict[str, str]:
+        """Fetch all of os.environ key:pair values."""
+        for key, value in os.environ.items():
+            self.log.debug("Found, %s : ***%s", key, value[-(len(value) // 4) :])
+
+        return dict(os.environ)

--- a/tests/environ_loader_test.py
+++ b/tests/environ_loader_test.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from eggviron.environ_loader import EnvironLoader
+
+
+@pytest.fixture(autouse=True)
+def clear_environ() -> None:
+    # Clearing the os.environ before tests will help prevent leaking any actual secrets
+    # in the environment during a failure in the test run-time.
+    for key in os.environ.keys():
+        os.environ.pop(key)
+
+    os.environ["SOME_FAKE_KEY"] = "foo"
+
+
+def test_environ_loader_returns_os_environ() -> None:
+    # This is a simple loader doing a simple task
+    expected_results = dict(os.environ)
+
+    results = EnvironLoader().run()
+
+    assert results == expected_results


### PR DESCRIPTION
This is as simple as it sounds. Returns the values of `os.environ` as a new dict when run.

Future iterations could have initialization options to help filter what is loaded. Not needed now.