### PR TITLE
Do not validate key names

### DIFF
--- a/src/eggviron/envfile_loader.py
+++ b/src/eggviron/envfile_loader.py
@@ -17,7 +17,6 @@ import re
 
 _RE_LTQUOTES = re.compile(r"([\"'])(.*)\1$|^(.*)$")
 _EXPORT_PREFIX = re.compile(r"^\s*?export\s")
-_VALIDATE_KEY = re.compile(r"^[^\s]+$")
 
 
 class EnvFileLoader:
@@ -72,8 +71,6 @@ class EnvFileLoader:
             key, value = line.split("=", 1)
 
             key = _strip_export(key).strip()
-            if not _is_valid_key(key):
-                raise ValueError(f"Line {idx}: Invalid key, '{key}'")
 
             value = value.strip()
 
@@ -93,8 +90,3 @@ def _remove_lt_quotes(in_: str) -> str:
 def _strip_export(in_: str) -> str:
     """Removes leading 'export ' prefix"""
     return re.sub(_EXPORT_PREFIX, "", in_)
-
-
-def _is_valid_key(in_: str) -> bool:
-    """True if the key is value."""
-    return bool(_VALIDATE_KEY.match(in_))

--- a/tests/envfile_loader_test.py
+++ b/tests/envfile_loader_test.py
@@ -30,6 +30,7 @@ leading_broken_single_nested_quoted = "Some quoted value"'
 trailing_broken_double_nested_quoted = "'Some quoted value'
 trailing_broken_single_nested_quoted = '"Some quoted value"
 export export_example = elpmaxe
+actually valid = neat
 """
 
 
@@ -66,14 +67,12 @@ def test_missing_equals_raises_value_error() -> None:
             loader.run()
 
 
-def test_space_in_key_raises_value_error() -> None:
-    # Use a comment line missing the # to assert this failure catch
-    contents = "FOO BAR=BAZ"
-    with create_file(contents) as file_path:
-        loader = EnvFileLoader(file_path)
+def test_spaces_in_keys(loader: EnvFileLoader) -> None:
+    # It is valid to have a space in environment variables
+    # https://pubs.opengroup.org/onlinepubs/9799919799/
+    results = loader.run()
 
-        with pytest.raises(ValueError, match="Line 1: Invalid key, 'FOO BAR'"):
-            loader.run()
+    assert results["actually valid"] == "neat"
 
 
 def test_export_lines_are_valid(loader: EnvFileLoader) -> None:


### PR DESCRIPTION
Key names can consist of just about any character. [IEEE 1003.1](https://pubs.opengroup.org/onlinepubs/9799919799/) states that only portable characters are to be used. I don't think there's value in enforcing this for names.