### PR TITLE
Rename test dep group to dev

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -71,7 +71,7 @@ def run_tests_with_coverage(session: nox.Session) -> None:
         session.posargs.remove("no-config")
         extra = ["--no-config"]
 
-    session.run_install("uv", "sync", "--group", "test", *SYNC_ARGS, *extra)
+    session.run_install("uv", "sync", *SYNC_ARGS, *extra)
 
     coverage = functools.partial(session.run, "uv", "run", *extra, "coverage")
 
@@ -89,7 +89,7 @@ def run_tests_with_coverage(session: nox.Session) -> None:
 @nox.session(name="combine", python=False)
 def combine_coverage(session: nox.Session) -> None:
     """Combine parallel-mode coverage files and produce reports."""
-    session.run_install("uv", "sync", "--group", "test", *SYNC_ARGS)
+    session.run_install("uv", "sync", *SYNC_ARGS)
 
     coverage = functools.partial(session.run, "uv", "run", "coverage")
 
@@ -102,7 +102,7 @@ def combine_coverage(session: nox.Session) -> None:
 @nox.session(name="lint", python=False)
 def run_linters(session: nox.Session) -> None:
     """Run code linters, and type checking against all files."""
-    session.run_install("uv", "sync", "--group", "test", "--group", "lint", *SYNC_ARGS)
+    session.run_install("uv", "sync", "--group", "lint", *SYNC_ARGS)
 
     for linter_args in LINTERS:
         session.run("uv", "run", *linter_args)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ lint = [
     "flake8-pep585",
     "mypy",
 ]
-test = [
+dev = [
     "pytest",
     "pytest-randomly",
     "coverage",

--- a/uv.lock
+++ b/uv.lock
@@ -147,6 +147,11 @@ name = "eggviron"
 source = { editable = "." }
 
 [package.dev-dependencies]
+dev = [
+    { name = "coverage" },
+    { name = "pytest" },
+    { name = "pytest-randomly" },
+]
 format = [
     { name = "black" },
     { name = "isort" },
@@ -156,16 +161,16 @@ lint = [
     { name = "flake8-builtins" },
     { name = "flake8-pep585" },
     { name = "mypy" },
-]
-test = [
-    { name = "coverage" },
-    { name = "pytest" },
-    { name = "pytest-randomly" },
 ]
 
 [package.metadata]
 
 [package.metadata.requires-dev]
+dev = [
+    { name = "coverage" },
+    { name = "pytest" },
+    { name = "pytest-randomly" },
+]
 format = [
     { name = "black" },
     { name = "isort" },
@@ -175,11 +180,6 @@ lint = [
     { name = "flake8-builtins" },
     { name = "flake8-pep585" },
     { name = "mypy" },
-]
-test = [
-    { name = "coverage" },
-    { name = "pytest" },
-    { name = "pytest-randomly" },
 ]
 
 [[package]]


### PR DESCRIPTION
The test depenency group is always required during development. It should be called dev. uv always installs the dev group by default.