### PR TITLE
Mutate `os.environ` with Eggviron actions

### DIFF
--- a/src/eggviron/_eggviron.py
+++ b/src/eggviron/_eggviron.py
@@ -137,14 +137,15 @@ class Eggviron:
             Eggviron: The mutated instance of self.
         """
         for _loader in loader:
+            results = _loader.run()
+
             if self._strict:
-                results = _loader.run()
                 conflicts = [key for key in results if key in self._loaded_values]
                 if conflicts:
                     msg = f"Key '{conflicts[0]}' already exists. Offending loader: '{_loader.name}'"
                     raise KeyError(msg)
 
-            self._loaded_values.update(_loader.run())
+            self._loaded_values.update(results)
 
         return self
 

--- a/tests/eggviron_test.py
+++ b/tests/eggviron_test.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 import pytest
 
 from eggviron import Eggviron
@@ -120,6 +122,44 @@ def test_load_with_multiple_loaders_not_strict() -> None:
     assert values["luz"] == "good witch"
     assert values["owl"] == "lady"
     assert values["boiling"] == "sea"
+
+
+def test_loader_mutates_environ() -> None:
+    """By default, Eggviron will mutate the os.environ as it changes"""
+    carton = Eggviron()
+    loader = MockLoader({"luz": "human"})
+
+    carton.load(loader)
+
+    assert os.getenv("luz") == "human"
+
+
+def test_setitem_mutates_environ() -> None:
+    """By default, Eggviron will mutate the os.environ as it changes"""
+    carton = Eggviron()
+
+    carton["owl"] = "lady"
+
+    assert os.getenv("owl") == "lady"
+
+
+def test_loader_does_not_mutate_environ() -> None:
+    """Eggviron will not mutate the os.environ when flag is flipped"""
+    carton = Eggviron(mutate_environ=False)
+    loader = MockLoader({"luz": "human"})
+
+    carton.load(loader)
+
+    assert "luz" not in os.environ
+
+
+def test_setitem_does_not_mutate_environ() -> None:
+    """Eggviron will not mutate the os.environ when flag is flipped"""
+    carton = Eggviron(mutate_environ=False)
+
+    carton["owl"] = "lady"
+
+    assert "owl" not in os.environ
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The default behavior of an Eggviron instance will be to mutate the
`os.environ` values as Eggviron `__setitem__()` is called or `load()` is
called. For loaders, the `os.environ` is updated after *each* loader
provided.

This will allow the dev to load a `.env` file with values needed for
additional loaders. As an example: using the `.env` file to provide the
secrets needed to use the AWS Parameter Store loader.
