### PR TITLE
Allow for `in` keyword against Eggviron

### DIFF
--- a/src/eggviron/_eggviron.py
+++ b/src/eggviron/_eggviron.py
@@ -151,6 +151,9 @@ class Eggviron:
         if self._mutate:
             os.environ.pop(key, None)
 
+    def __contains__(self, key: str) -> bool:
+        return key in self._loaded_values
+
     def load(self, *loader: Loader) -> Eggviron:
         """
         Use a loader to update the loaded values. Loaders are used in the order provided.

--- a/tests/eggviron_test.py
+++ b/tests/eggviron_test.py
@@ -123,7 +123,7 @@ def test_del_item(carton: Eggviron) -> None:
     """Remove an existing item on del keyword use."""
     del carton["foo"]
 
-    assert "foo" not in carton.loaded_values
+    assert "foo" not in carton
 
 
 def test_delitem_mutates_environ() -> None:
@@ -144,7 +144,7 @@ def test_delitem_does_not_mutate_environ() -> None:
 
     del carton["owl"]
 
-    assert "owl" not in carton.loaded_values
+    assert "owl" not in carton
     assert "owl" in os.environ
 
 


### PR DESCRIPTION
Implement the `__contains__` method to allow for `in` checks against the Eggviron instance. Removes the need to reference `loaded_values` attribute.