### PR TITLE
Fetch parameters from AWS by name and path

### DIFF
--- a/src/eggviron/_awsparamstore_loader.py
+++ b/src/eggviron/_awsparamstore_loader.py
@@ -11,6 +11,15 @@ import dataclasses
 import logging
 from typing import overload
 
+try:
+    import boto3
+    from botocore.exceptions import BotoCoreError
+    from botocore.exceptions import ClientError
+
+except ImportError as err:  # pragma: no cover
+    error_msg = "boto3 not installed. Install the 'aws' extra to use AWSParamStore."
+    raise ImportError(error_msg) from err
+
 
 @dataclasses.dataclass(slots=True)
 class AWSParamStoreException(Exception):
@@ -33,17 +42,6 @@ class AWSParamStoreException(Exception):
             http_headers=err.response["ResponseMetadata"]["HTTPHeaders"],
             retry_attempts=err.response["ResponseMetadata"]["RetryAttempts"],
         )
-
-
-try:
-    import boto3
-    from botocore.exceptions import BotoCoreError
-    from botocore.exceptions import ClientError
-
-except ImportError:  # pragma: no cover
-    error_msg = "boto3 not installed. Install the 'aws' extra to use AWSParamStore."
-    raise AWSParamStoreException(error_msg)
-
 
 class AWSParamStore:
     """Load parameter store value(s) from AWS Parameter Store (SSM)."""

--- a/tests/awsparamstore_loader_test.py
+++ b/tests/awsparamstore_loader_test.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator
+from unittest.mock import patch
 
 import pytest
 from moto import mock_aws
@@ -22,6 +23,7 @@ def mock_ssm() -> Generator[None, None, None]:
         client.put_parameter(Name="/foo/bar", Value="foo.bar", Type="String")
         client.put_parameter(Name="/foo/baz", Value="foo.baz", Type="SecureString")
         client.put_parameter(Name="/foo/biz", Value="foo,biz", Type="StringList")
+        client.put_parameter(Name="/foo/foo2/bar", Value="foo foo bar", Type="String")
 
         yield None
 
@@ -96,3 +98,49 @@ def test_run_raises_exception_when_name_not_found() -> None:
 
     with pytest.raises(AWSParamStoreException):
         AWSParamStore(parameter_name="/oo/bar", aws_region=DEFAULT_REGION).run()
+
+
+@pytest.mark.usefixtures("mock_ssm")
+def test_run_returns_parameters_by_path_without_truncation() -> None:
+    """Return all paramters found in the path, nonrecursively, with pagination"""
+    expected = {
+        "/foo/bar": "foo.bar",
+        "/foo/baz": "kms:alias/aws/ssm:foo.baz",
+        "/foo/biz": "foo,biz",
+    }
+    clazz = AWSParamStore(parameter_path="/foo/", aws_region=DEFAULT_REGION)
+
+    with patch("eggviron._awsparamstore_loader._MAX_RESULTS", 1):
+        results = clazz.run()
+
+    assert results == expected
+
+
+@pytest.mark.usefixtures("mock_ssm")
+def test_run_returns_parameters_by_path_within_truncation() -> None:
+    """Return all paramters found in the path, nonrecursively, with pagination"""
+    expected = {
+        "bar": "foo.bar",
+        "baz": "kms:alias/aws/ssm:foo.baz",
+        "biz": "foo,biz",
+    }
+    clazz = AWSParamStore(parameter_path="/foo/", aws_region=DEFAULT_REGION, truncate_key=True)
+
+    with patch("eggviron._awsparamstore_loader._MAX_RESULTS", 1):
+        results = clazz.run()
+
+    assert results == expected
+
+
+@pytest.mark.usefixtures("mock_ssm")
+def test_run_returns_parameters_by_path_raises_when_exceeds_max_pagination() -> None:
+    """A safe-guard against infinite loops, raise if max pagination attempts are reached."""
+    pattern = "Max pagination loop exceeded: 1"
+    clazz = AWSParamStore(parameter_path="/foo/", aws_region=DEFAULT_REGION)
+
+    with (
+        patch("eggviron._awsparamstore_loader._MAX_RESULTS", 1),
+        patch("eggviron._awsparamstore_loader._MAX_PAGINATION_LOOPS", 1),
+        pytest.raises(AWSParamStoreException, match=pattern),
+    ):
+        clazz.run()


### PR DESCRIPTION
Fetch parameters and return as a dict. Add the `truncate_key` optional parameter to the loader. Also adds the `recursive` optional parameter to loading by parameter path.