### PR TITLE
Allow for inline comments in .env files

### DIFF
--- a/src/eggviron/_envfile_loader.py
+++ b/src/eggviron/_envfile_loader.py
@@ -14,7 +14,7 @@ This `.env` example:
 
 ```conf
 # Example .env file
-export PASSWORD     = correct horse battery staple
+export PASSWORD     = correct horse battery staple  # great password
 USER_NAME           = "not_admin"
 MESSAGE             = '    Totally not an "admin" account logging in'
 ```
@@ -95,19 +95,27 @@ class EnvFileLoader:
 
             value = value.strip()
 
-            value = _remove_lt_quotes(value)
+            value, was_quoted = _remove_lt_quotes(value)
+
+            if not was_quoted:
+                value = _remove_inline_comment(value)
 
             loaded_values[key] = value
 
         return loaded_values
 
 
-def _remove_lt_quotes(in_: str) -> str:
+def _remove_lt_quotes(in_: str) -> tuple[str, bool]:
     """Removes matched leading and trailing single / double quotes"""
     m = _RE_LTQUOTES.match(in_)
-    return m.group(2) if m and m.group(2) else in_
+    return m.group(2) if m and m.group(2) else in_, bool(m and m.group(2))
 
 
 def _strip_export(in_: str) -> str:
     """Removes leading 'export ' prefix"""
     return re.sub(_EXPORT_PREFIX, "", in_)
+
+
+def _remove_inline_comment(value: str) -> str:
+    """Remove all characters after a comment, striping the resulting value"""
+    return value.split("#", 1)[0].strip()

--- a/tests/envfile_loader_test.py
+++ b/tests/envfile_loader_test.py
@@ -26,6 +26,9 @@ trailing_broken_double_nested_quoted = "'Some quoted value'
 trailing_broken_single_nested_quoted = '"Some quoted value"
 export export_example = elpmaxe
 actually valid = neat
+
+inline=comments # Are allowed
+quoted_inline="comments # are part of the quoted string"
 """
 
 
@@ -112,3 +115,17 @@ def test_leading_broken_double_nested_quotes(loader: EnvFileLoader) -> None:
     assert results["leading_broken_single_nested_quoted"] == '"Some quoted value"\''
     assert results["trailing_broken_double_nested_quoted"] == "\"'Some quoted value'"
     assert results["trailing_broken_single_nested_quoted"] == '\'"Some quoted value"'
+
+
+def test_inline_comments_are_ignored(loader: EnvFileLoader) -> None:
+    # If an inline comment is not quoted, ignore everything past the # character
+    results = loader.run()
+
+    assert results["inline"] == "comments"
+
+
+def test_quoted_inline_comments_are_retained(loader: EnvFileLoader) -> None:
+    # If an quoted string has a # in it, the full quoted string is still returned
+    results = loader.run()
+
+    assert results["quoted_inline"] == "comments # are part of the quoted string"


### PR DESCRIPTION
Allows for inline comments in .env files.

Example

```ini
foo=bar # with a comment
bar="foo # with quotes"
```

yields

```json
{
    "foo": "bar",
    "bar": "foo # with quotes"
}
```