### PR TITLE
.env inline comments require whitespace

### DIFF
--- a/src/eggviron/_envfile_loader.py
+++ b/src/eggviron/_envfile_loader.py
@@ -38,6 +38,7 @@ import re
 
 _RE_LTQUOTES = re.compile(r"^\s*?([\"'])(.*)\1$|^(.*)$")
 _EXPORT_PREFIX = re.compile(r"^\s*?export\s")
+_INLINE_COMMENT = re.compile(r"([^\s]+)(\s+#.*)")
 
 
 class EnvFileLoader:
@@ -98,7 +99,7 @@ class EnvFileLoader:
             if not was_quoted:
                 value = _remove_inline_comment(value)
 
-            loaded_values[key] = value
+            loaded_values[key] = value if was_quoted else value.strip()
 
         return loaded_values
 
@@ -114,6 +115,7 @@ def _strip_export(in_: str) -> str:
     return re.sub(_EXPORT_PREFIX, "", in_)
 
 
-def _remove_inline_comment(value: str) -> str:
-    """Remove all characters after a comment, striping the resulting value"""
-    return value.split("#", 1)[0].strip()
+def _remove_inline_comment(_in: str) -> str:
+    """Remove inline comments."""
+    m = _INLINE_COMMENT.match(_in)
+    return m.group(1) if m else _in

--- a/tests/envfile_loader_test.py
+++ b/tests/envfile_loader_test.py
@@ -29,6 +29,7 @@ actually valid = neat
 
 inline=comments # Are allowed
 quoted_inline="comments # are part of the quoted string"
+inline_comment=weak!@#$%password1234 # Inline require whitespace
 """
 
 
@@ -129,3 +130,10 @@ def test_quoted_inline_comments_are_retained(loader: EnvFileLoader) -> None:
     results = loader.run()
 
     assert results["quoted_inline"] == "comments # are part of the quoted string"
+
+
+def test_inline_comments_require_whitespace(loader: EnvFileLoader) -> None:
+    # Don't strip comments unless the # has leading whitespace
+    results = loader.run()
+
+    assert results["inline_comment"] == "weak!@#$%password1234"


### PR DESCRIPTION
This prevents a valid token or password that contains `#` from being stripped as an inline comment.