### PR TITLE
Inline comments after quoted content

### DIFF
--- a/src/eggviron/_envfile_loader.py
+++ b/src/eggviron/_envfile_loader.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 import logging
 import re
 
-_RE_LTQUOTES = re.compile(r"^\s*?([\"'])(.*)\1$")
+_RE_LTQUOTES = re.compile(r"^\s*?([\"'])(.*)\1(\s+#.*)?$")
 _EXPORT_PREFIX = re.compile(r"^\s*?export\s")
 _INLINE_COMMENT = re.compile(r"([^\s]+)(\s+#.*)")
 

--- a/src/eggviron/_envfile_loader.py
+++ b/src/eggviron/_envfile_loader.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 import logging
 import re
 
-_RE_LTQUOTES = re.compile(r"^\s*?([\"'])(.*)\1$|^(.*)$")
+_RE_LTQUOTES = re.compile(r"^\s*?([\"'])(.*)\1$")
 _EXPORT_PREFIX = re.compile(r"^\s*?export\s")
 _INLINE_COMMENT = re.compile(r"([^\s]+)(\s+#.*)")
 

--- a/tests/envfile_loader_test.py
+++ b/tests/envfile_loader_test.py
@@ -28,7 +28,7 @@ export export_example = elpmaxe
 actually valid = neat
 
 inline=comments # Are allowed
-quoted_inline="comments # are part of the quoted string"
+quoted_inline="comments # are part of the quoted string" # Inline still allowed
 inline_comment=weak!@#$%password1234 # Inline require whitespace
 """
 


### PR DESCRIPTION
Handles the case of a quoted value having an inline comment after it.

```ini
inline=comments # Are allowed
quoted_inline="comments # are part of the quoted string"
quoted_inline_comment="comments # are part of the quoted string" # Inline still allowed
inline_comment=weak!@#$%password1234 # Inline require whitespace
```

```json
{
  "inline": "comments",
  "quoted_inline": "comments # are part of the quoted string",
  "quoted_inline_comment": "comments # are part of the quoted string",
  "inline_comment": "weak!@#$%password1234"
}
```
